### PR TITLE
Command topic support both JointTrajectory and JointState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   hardware_interface
   sensor_msgs
+  trajectory_msgs
 )
 
 find_package(ament_cmake REQUIRED)

--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -35,6 +35,8 @@
 // C++
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <variant>
 
 // ROS
 #include <hardware_interface/handle.hpp>
@@ -47,9 +49,15 @@
 #include <rclcpp/subscription.hpp>
 
 #include <sensor_msgs/msg/joint_state.hpp>
-
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 namespace topic_based_ros2_control
 {
+
+enum class TopicBasedCmdType
+{
+  JOINT_STATE,
+  JOINT_TRAJECTORY
+};
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 class TopicBasedSystem : public hardware_interface::SystemInterface
@@ -66,8 +74,23 @@ public:
   hardware_interface::return_type write(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) override;
 
 private:
+  struct MimicJoint
+  {
+    std::size_t joint_index;
+    std::size_t mimicked_joint_index;
+    double multiplier = 1.0;
+  };
+  std::vector<MimicJoint> mimic_joints_;
+  void updateMimicJoint(const MimicJoint& mimic_joint, sensor_msgs::msg::JointState& joint_state) const;
+  void updateMimicJointTrajectory(const MimicJoint& mimic_joint,
+                                  trajectory_msgs::msg::JointTrajectoryPoint& point) const;
+  void publishJointState();
+  void publishJointTrajectory();
+
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_states_subscriber_;
-  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_commands_publisher_;
+  using JointCommandPublisher = std::variant<rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr,
+                                             rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr>;
+  JointCommandPublisher topic_based_joint_commands_publisher_;
   rclcpp::Node::SharedPtr node_;
   sensor_msgs::msg::JointState latest_joint_state_;
   bool sum_wrapped_joint_states_{ false };
@@ -80,28 +103,25 @@ private:
                                                       hardware_interface::HW_IF_ACCELERATION,
                                                       hardware_interface::HW_IF_EFFORT };
 
-  struct MimicJoint
-  {
-    std::size_t joint_index;
-    std::size_t mimicked_joint_index;
-    double multiplier = 1.0;
-  };
-  std::vector<MimicJoint> mimic_joints_;
-
   /// The size of this vector is (standard_interfaces_.size() x nr_joints)
   std::vector<std::vector<double>> joint_commands_;
   std::vector<std::vector<double>> joint_states_;
-
+  TopicBasedCmdType joint_commands_type_ = TopicBasedCmdType::JOINT_STATE;
   // If the difference between the current joint state and joint command is less than this value,
   // the joint command will not be published.
   double trigger_joint_command_threshold_ = 1e-5;
   // If the difference between the current joint state and joint command is more than this value,
   // the joint command will not be published.
   double block_joint_command_threshold_ = 0.5;
+  // Only fill the position field in the joint command msg
+  bool position_cmd_only_ = false;
+  // Time from start for the joint trajectory message
+  double time_from_start_ = 0.1;
 
   template <typename HandleType>
   bool getInterface(const std::string& name, const std::string& interface_name, const size_t vector_index,
                     std::vector<std::vector<double>>& values, std::vector<HandleType>& interfaces);
+  TopicBasedCmdType stringToCommandType(const std::string& type_str);
 };
 
 }  // namespace topic_based_ros2_control

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
     <depend>rclcpp</depend>
     <depend>hardware_interface</depend>
     <depend>sensor_msgs</depend>
-
+    <depend>trajectory_msgs</depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>picknik_ament_copyright</test_depend>
     <test_depend>ros2_control_test_assets</test_depend>

--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -133,6 +133,22 @@ CallbackReturn TopicBasedSystem::on_init(const hardware_interface::HardwareInfo&
     }
     return default_value;
   };
+  // Load parameters from the hardware interface
+  time_from_start_ = std::stod(get_hardware_parameter("time_from_start", "0.1"));
+  position_cmd_only_ = get_hardware_parameter("position_cmd_only", "false") == "true";
+  std::string joint_commands_type_str = get_hardware_parameter("joint_commands_type", "sensor_msgs/JointState");
+  try
+  {
+    joint_commands_type_ = stringToCommandType(joint_commands_type_str);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "%s", e.what());
+    return CallbackReturn::ERROR;
+  }
+
+  block_joint_command_threshold_ = std::stod(get_hardware_parameter("block_joint_command_threshold", "0.5"));
+  trigger_joint_command_threshold_ = std::stod(get_hardware_parameter("trigger_joint_command_threshold", "1e-5"));
 
   // Add random ID to prevent warnings about multiple publishers within the same node
   rclcpp::NodeOptions options;
@@ -140,13 +156,21 @@ CallbackReturn TopicBasedSystem::on_init(const hardware_interface::HardwareInfo&
 
   node_ = rclcpp::Node::make_shared("_", options);
 
-  if (auto it = info_.hardware_parameters.find("trigger_joint_command_threshold"); it != info_.hardware_parameters.end())
+  switch (joint_commands_type_)
   {
-    trigger_joint_command_threshold_ = std::stod(it->second);
+    case TopicBasedCmdType::JOINT_STATE:
+      topic_based_joint_commands_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(
+          get_hardware_parameter("joint_commands_topic", "/robot_joint_commands"), rclcpp::QoS(1));
+      break;
+    case TopicBasedCmdType::JOINT_TRAJECTORY:
+      topic_based_joint_commands_publisher_ = node_->create_publisher<trajectory_msgs::msg::JointTrajectory>(
+          get_hardware_parameter("joint_commands_topic", "/robot_joint_commands"), rclcpp::QoS(1));
+      break;
+    default:
+      RCLCPP_ERROR(node_->get_logger(), "Unsupported joint_commands_type");
+      return CallbackReturn::ERROR;
   }
 
-  topic_based_joint_commands_publisher_ = node_->create_publisher<sensor_msgs::msg::JointState>(
-      get_hardware_parameter("joint_commands_topic", "/robot_joint_commands"), rclcpp::QoS(1));
   topic_based_joint_states_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
       get_hardware_parameter("joint_states_topic", "/robot_joint_states"), rclcpp::SensorDataQoS(),
       [this](const sensor_msgs::msg::JointState::SharedPtr joint_state) { latest_joint_state_ = *joint_state; });
@@ -162,18 +186,6 @@ CallbackReturn TopicBasedSystem::on_init(const hardware_interface::HardwareInfo&
     initial_states_as_initial_cmd_ = true;
     ready_to_send_cmds_ = false;
   }
-
-  // Check if return of get_hardware_parameter is double type. If not, turn it from string to double type
-  try
-  {
-    block_joint_command_threshold_ = std::stod(get_hardware_parameter("block_joint_command_threshold", "0.5"));
-  }
-  catch (const std::exception& e)
-  {
-    RCLCPP_ERROR(node_->get_logger(), "Failed to convert block_joint_command_threshold to double: %s", e.what());
-    return CallbackReturn::ERROR;
-  }
-
   return CallbackReturn::SUCCESS;
 }
 
@@ -308,62 +320,172 @@ hardware_interface::return_type TopicBasedSystem::write(const rclcpp::Time& /*ti
     return hardware_interface::return_type::OK;
   }
 
+  switch (joint_commands_type_)
+  {
+    case TopicBasedCmdType::JOINT_STATE:
+      publishJointState();
+      break;
+    case TopicBasedCmdType::JOINT_TRAJECTORY:
+      publishJointTrajectory();
+      break;
+    default:
+      RCLCPP_ERROR(node_->get_logger(), "Unsupported joint_commands_type");
+      return hardware_interface::return_type::ERROR;
+  }
+
+  return hardware_interface::return_type::OK;
+}
+
+void TopicBasedSystem::publishJointState()
+{
   sensor_msgs::msg::JointState joint_state;
+  joint_state.header.stamp = node_->now();
+
+  // Pre-allocate vectors to avoid reallocations
+  joint_state.name.reserve(info_.joints.size());
+  joint_state.position.reserve(info_.joints.size());
+  joint_state.velocity.reserve(info_.joints.size());
+  joint_state.effort.reserve(info_.joints.size());
+
+  // Fill joint state message
   for (std::size_t i = 0; i < info_.joints.size(); ++i)
   {
     joint_state.name.push_back(info_.joints[i].name);
-    joint_state.header.stamp = node_->now();
-    // only send commands to the interfaces that are defined for this joint
+
     for (const auto& interface : info_.joints[i].command_interfaces)
     {
       if (interface.name == hardware_interface::HW_IF_POSITION)
       {
         joint_state.position.push_back(joint_commands_[POSITION_INTERFACE_INDEX][i]);
       }
-      else if (interface.name == hardware_interface::HW_IF_VELOCITY)
+      if (!position_cmd_only_)
       {
-        joint_state.velocity.push_back(joint_commands_[VELOCITY_INTERFACE_INDEX][i]);
-      }
-      else if (interface.name == hardware_interface::HW_IF_EFFORT)
-      {
-        joint_state.effort.push_back(joint_commands_[EFFORT_INTERFACE_INDEX][i]);
-      }
-      else
-      {
-        RCLCPP_WARN_ONCE(node_->get_logger(), "Joint '%s' has unsupported command interfaces found: %s.",
-                         info_.joints[i].name.c_str(), interface.name.c_str());
+        if (interface.name == hardware_interface::HW_IF_VELOCITY)
+        {
+          joint_state.velocity.push_back(joint_commands_[VELOCITY_INTERFACE_INDEX][i]);
+        }
+        else if (interface.name == hardware_interface::HW_IF_EFFORT)
+        {
+          joint_state.effort.push_back(joint_commands_[EFFORT_INTERFACE_INDEX][i]);
+        }
       }
     }
   }
 
+  // Handle mimic joints
   for (const auto& mimic_joint : mimic_joints_)
   {
-    for (const auto& interface : info_.joints[mimic_joint.mimicked_joint_index].command_interfaces)
+    updateMimicJoint(mimic_joint, joint_state);
+  }
+
+  std::get<rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr>(topic_based_joint_commands_publisher_)
+      ->publish(joint_state);
+}
+
+void TopicBasedSystem::publishJointTrajectory()
+{
+  trajectory_msgs::msg::JointTrajectory joint_trajectory;
+  joint_trajectory.points.resize(1);
+  joint_trajectory.joint_names.reserve(info_.joints.size());
+
+  auto& point = joint_trajectory.points[0];
+  point.positions.reserve(info_.joints.size());
+  point.velocities.reserve(info_.joints.size());
+  point.effort.reserve(info_.joints.size());
+  point.time_from_start = rclcpp::Duration::from_seconds(time_from_start_);
+
+  // Fill trajectory message
+  for (std::size_t i = 0; i < info_.joints.size(); ++i)
+  {
+    joint_trajectory.joint_names.push_back(info_.joints[i].name);
+
+    for (const auto& interface : info_.joints[i].command_interfaces)
     {
       if (interface.name == hardware_interface::HW_IF_POSITION)
       {
-        joint_state.position[mimic_joint.joint_index] =
-            mimic_joint.multiplier * joint_state.position[mimic_joint.mimicked_joint_index];
+        point.positions.push_back(joint_commands_[POSITION_INTERFACE_INDEX][i]);
       }
-      else if (interface.name == hardware_interface::HW_IF_VELOCITY)
+      if (!position_cmd_only_)
       {
-        joint_state.velocity[mimic_joint.joint_index] =
-            mimic_joint.multiplier * joint_state.velocity[mimic_joint.mimicked_joint_index];
-      }
-      else if (interface.name == hardware_interface::HW_IF_EFFORT)
-      {
-        joint_state.effort[mimic_joint.joint_index] =
-            mimic_joint.multiplier * joint_state.effort[mimic_joint.mimicked_joint_index];
+        if (interface.name == hardware_interface::HW_IF_VELOCITY)
+        {
+          point.velocities.push_back(joint_commands_[VELOCITY_INTERFACE_INDEX][i]);
+        }
+        else if (interface.name == hardware_interface::HW_IF_EFFORT)
+        {
+          point.effort.push_back(joint_commands_[EFFORT_INTERFACE_INDEX][i]);
+        }
       }
     }
   }
 
-  if (rclcpp::ok())
+  // Handle mimic joints for trajectory
+  for (const auto& mimic_joint : mimic_joints_)
   {
-    topic_based_joint_commands_publisher_->publish(joint_state);
+    updateMimicJointTrajectory(mimic_joint, point);
   }
 
-  return hardware_interface::return_type::OK;
+  std::get<rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr>(topic_based_joint_commands_publisher_)
+      ->publish(joint_trajectory);
+}
+
+void TopicBasedSystem::updateMimicJoint(const MimicJoint& mimic_joint, sensor_msgs::msg::JointState& joint_state) const
+{
+  if (!joint_state.position.empty())
+  {
+    joint_state.position[mimic_joint.joint_index] =
+        mimic_joint.multiplier * joint_state.position[mimic_joint.mimicked_joint_index];
+  }
+  if (!position_cmd_only_)
+  {
+    if (!joint_state.velocity.empty())
+    {
+      joint_state.velocity[mimic_joint.joint_index] =
+          mimic_joint.multiplier * joint_state.velocity[mimic_joint.mimicked_joint_index];
+    }
+    if (!joint_state.effort.empty())
+    {
+      joint_state.effort[mimic_joint.joint_index] =
+          mimic_joint.multiplier * joint_state.effort[mimic_joint.mimicked_joint_index];
+    }
+  }
+}
+
+void TopicBasedSystem::updateMimicJointTrajectory(const MimicJoint& mimic_joint,
+                                                  trajectory_msgs::msg::JointTrajectoryPoint& point) const
+{
+  if (!point.positions.empty())
+  {
+    point.positions[mimic_joint.joint_index] =
+        mimic_joint.multiplier * point.positions[mimic_joint.mimicked_joint_index];
+  }
+  if (!position_cmd_only_)
+  {
+    if (!point.velocities.empty())
+    {
+      point.velocities[mimic_joint.joint_index] =
+          mimic_joint.multiplier * point.velocities[mimic_joint.mimicked_joint_index];
+    }
+    if (!point.effort.empty())
+    {
+      point.effort[mimic_joint.joint_index] = mimic_joint.multiplier * point.effort[mimic_joint.mimicked_joint_index];
+    }
+  }
+}
+
+TopicBasedCmdType TopicBasedSystem::stringToCommandType(const std::string& type_str)
+{
+  static const std::unordered_map<std::string, TopicBasedCmdType> type_map = {
+    { "sensor_msgs/JointState", TopicBasedCmdType::JOINT_STATE },
+    { "trajectory_msgs/JointTrajectory", TopicBasedCmdType::JOINT_TRAJECTORY }
+  };
+
+  auto it = type_map.find(type_str);
+  if (it == type_map.end())
+  {
+    throw std::runtime_error("Unsupported joint_commands_type: " + type_str);
+  }
+  return it->second;
 }
 }  // end namespace topic_based_ros2_control
 


### PR DESCRIPTION
Add param as the following and optimize some code structure:
1. joint_command_type: Switch command topic type between JointTrajectory and JointState
2. position_cmd_only: Fill position field in command message and keep other information from command (velocity, acceleration, errort... ) empty to meet the topic format in shadow robot.
3. time_from_start when publish command type is JointTrajectory, these values are not the same in arm, hand and wrist in shadow robot system.
Related PR: 
https://github.com/Develop-SF/sns_autonomy/compare/main...SFhmichael/feature/topic_based_pub_traj
https://github.com/Develop-SF/sns_description/compare/main...SFhmichael/feature/pub_traj
https://github.com/Develop-SF/sns_docker/compare/SFhmichael/feature/topic_based_pub_traj?expand=1