### PR TITLE
Add timestamp in published joint_trajectory topic

### DIFF
--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -387,7 +387,7 @@ void TopicBasedSystem::publishJointTrajectory()
   trajectory_msgs::msg::JointTrajectory joint_trajectory;
   joint_trajectory.points.resize(1);
   joint_trajectory.joint_names.reserve(info_.joints.size());
-
+  joint_trajectory.header.stamp = rclcpp::Clock().now();
   auto& point = joint_trajectory.points[0];
   point.positions.reserve(info_.joints.size());
   point.velocities.reserve(info_.joints.size());


### PR DESCRIPTION
Without time stamp, sr_trajectory_studio made action failed.
Please refer to https://www.notion.so/shennongshi/Recorded-joint-command-from-ROS2-side-cannot-be-replay-by-sr_trajectory_studio-19fd6fdefaa480148a99d7f0df980092?pvs=4 for detailed description 